### PR TITLE
Allow graph download as PNG

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -703,7 +703,7 @@ $('#err-alert').hide();
                                   <div class="graphExport">
                                     <div class="btn-group-horizontal">
                                       <div class="makecsv btn btn-success" data-localize='export_csv'>Export Graph to CSV File</div>&nbsp;&nbsp;
-                                      <div id="makeG" class="makeGraph btn btn-success" data-localize='export_svg'>Export Graph to SVG Image</div>
+                                      <div id="makeG" class="makeGraph btn btn-success" data-localize='export_svg'>Save Graph as Image</div>
                                     </div>
                                     <div class="download-graph"></div>
                                     <div class="modal fade csv-modal" role="dialog" tabindex="-1" aria-hidden="true">

--- a/assets/mr-plotter/js/frontend.js
+++ b/assets/mr-plotter/js/frontend.js
@@ -293,8 +293,28 @@ function createPlotDownload(self) {
   var plotHeight = chartElem.getAttribute("height"); //Math.max(, legend.getAttribute("height") + 100);
     var xmlData = '<svg xmlns="http://www.w3.org/2000/svg" width="' + plotWidth + '" height="' + plotHeight + '" font-family="serif" font-size="16px">'
         + '<defs><style type="text/css"><![CDATA[' + graphStyle + ']]></style></defs>' + chartData + '</svg>';
+
+var canvas = document.createElement('canvas');
+var context = canvas.getContext('2d');
+var image = new Image;
+image.src = "data:image/svg+xml," + xmlData;
+image.onload = function() {
+    debugger;
+    canvas.height = plotHeight;
+    canvas.width = plotWidth;
+    context.drawImage(image, 0, 0);
+    var a = document.createElement("a");
+    a.download = "graph.png";
+    a.href = canvas.toDataURL("image/png");
+    a.innerHTML = "Download as PNG";
+    var wrapper = document.createElement('div');
+    wrapper.appendChild(a);
+    downloadAnchor.insertAdjacentHTML('beforeBegin', "<div>(created " + (new Date()).toLocaleString() + ", local time)</div>");
+    downloadAnchor.insertAdjacentElement('beforeBegin', wrapper);
+};
+
     var downloadAnchor = document.createElement("a");
-    downloadAnchor.innerHTML = "Download Image (created " + (new Date()).toLocaleString() + ", local time)";
+    downloadAnchor.innerHTML = "Download as SVG";
     downloadAnchor.setAttribute("href", 'data:application/octet-stream;charset=utf-8,' + encodeURIComponent(xmlData));
     downloadAnchor.setAttribute("download", "graph.svg");
     // var da = 'data:application/octet-stream;charset=utf-8,' + encodeURIComponent(xmlData);


### PR DESCRIPTION
Normally when you click the button in the UI to export the graph as an image, it creates a link that gives you an SVG. SVGs are amazingly enough not supported in Google Docs or MS Office.

This code adds the option to save the file as a PNG as well making it easier to include these images in reports.